### PR TITLE
docs(README.md): readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ class MySDK extends SDK
             ),
             client: HttpClient::build(),
             container: Container::getInstance(),
-            strategy: new NullStrategy()),
+            strategy: new NullStrategy(),
         );
     }
 

--- a/README.md
+++ b/README.md
@@ -240,4 +240,4 @@ composer run test
 
 ## LICENSE
 
-The MIT LIcense (MIT). Please see [License File](./LICENSE) for more information.
+The MIT License (MIT). Please see [License File](./LICENSE) for more information.


### PR DESCRIPTION
Under the Building an SDK header, the example code, has one extra parenthesis like so `strategy: new NullStrategy()),`. 

Fix uppercase I in the under the License header too.

Small things but just noticed them, thought, I'd throw it into a PR.

I hope this is useful